### PR TITLE
add docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.8
+
+ENV FLASK_ENV=development
+ENV FLASK_APP=app.py
+
+WORKDIR /
+RUN pip install flask
+COPY . /
+
+CMD flask run --host=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # backend-sqlite
+
 prototype backend implementation for the STRICT protocol
 
 This backend was developed for testing of the app. It is currently deployed [here](https://api.ito-app.org/get_uuids).
 
 It is no longer being developed.
 
-run using flask:
-`FLASK_APP=app.py FLASK_ENV=development flask run --host=0.0.0.0`
+## Run using flask
+
+```sh
+FLASK_APP=app.py FLASK_ENV=development flask run --host=0.0.0.0
+```
+
+## Run with docker compose
+
+```sh
+docker-compose up
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+  backend-sqlite:
+    image: ito/backend-sqlite:latest
+    build: .
+    ports:
+      - 0.0.0.0:5000:5000


### PR DESCRIPTION
This adds a docker compose setup to quickly spin up a docker container without setting up a python dev environment first.